### PR TITLE
진미령 / 1주차

### DIFF
--- a/miir-jj/BOJ1182/BOJ1182.java
+++ b/miir-jj/BOJ1182/BOJ1182.java
@@ -4,9 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.StringTokenizer;
-/**
- * 부분수열의 합
- */
+
 public class BOJ1182 {
 
 	public static void main(String[] args) throws IOException {

--- a/miir-jj/BOJ1182/BOJ1182.java
+++ b/miir-jj/BOJ1182/BOJ1182.java
@@ -1,0 +1,45 @@
+package BOJ0211;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+/**
+ * 부분수열의 합
+ */
+public class BOJ1182 {
+
+	public static void main(String[] args) throws IOException {
+		int N, S;
+		int[] num;
+		int result=0;
+		int sum=0;
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		N = Integer.parseInt(st.nextToken());
+		S = Integer.parseInt(st.nextToken());
+		st = new StringTokenizer(br.readLine(), " ");
+		
+		num = new int[N];
+		
+		for (int i = 0; i < N; i++) {
+			num[i] = Integer.parseInt(st.nextToken());
+		}
+		for (int i = 1, end = 2 << (N - 1); i < end; i++) {//0인 경우 제외하고
+			sum=0;
+			for (int j = 0; j < N; j++) {
+				if((i & 1 << j) != 0) {
+					sum+=num[j];
+				}
+			}
+			if(sum==S) {
+				result++;
+				System.out.println(i);
+			}
+		}
+		System.out.println(result);
+
+	}
+
+}

--- a/miir-jj/BOJ1303/BOJ1303.java
+++ b/miir-jj/BOJ1303/BOJ1303.java
@@ -1,0 +1,79 @@
+package boj_2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/** 전투 */
+public class BOJ1303 {
+
+	static char[][] map;
+	static int N, M;
+	static int[] dr = { -1, 1, 0, 0 };
+	static int[] dc = { 0, 0, -1, 1 };
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		map = new char[M][N];
+
+		for (int i = 0; i < M; i++) {
+			String s = br.readLine();
+			for (int j = 0; j < N; j++) {
+				map[i][j] = s.charAt(j);
+			}
+		}
+		System.out.println(findTeam('W')+" "+findTeam('B'));
+	}
+
+	public static int findTeam(char c) {
+		int num = 0;
+		int sum = 0;
+		Queue<int[]> team = new LinkedList<int[]>();
+		boolean[][] isVisited = new boolean[M][N];
+
+		for (int i = 0; i < M; i++) {
+			for (int j = 0; j < N; j++) { //전체 맵을 돌며
+				if (map[i][j] == c &&!isVisited[i][j]) { //해당 팀이면서 아직 방문 전인 노드일 경우
+					team.offer(new int[] { i, j }); 
+					isVisited[i][j] = true; 
+					++num; 
+					int[] soldier=new int[2];
+					int nr,nc;
+					while(!team.isEmpty()) { //큐가 빌때까지 사방 탐색
+						soldier=team.poll();
+						for(int k=0;k<dr.length;k++) {
+							nr=soldier[0]+dr[k];
+							nc=soldier[1]+dc[k];
+							
+							if(nr>-1&&nr<M&&nc>-1&&nc<N&&map[nr][nc]==c&&!isVisited[nr][nc]) {
+								team.offer(new int[] {nr,nc});
+								isVisited[nr][nc]=true;
+								++num;
+								
+							}
+						}
+					}
+				}
+				sum+=num*num; //한번 큐가 비면->주위에 같은 팀 없다는 뜻으로 제곱해서 더해주고 다음 좌표로 이동
+				num=0;
+			}
+		}
+		return sum;
+	}
+
+}
+
+
+
+
+
+
+
+
+

--- a/miir-jj/BOJ16637/BOJ16637.java
+++ b/miir-jj/BOJ16637/BOJ16637.java
@@ -1,0 +1,92 @@
+package boj_2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class BOJ16637 {
+	static int N;
+	static Queue<Character> input;
+	static Queue<Character> order;
+	static int[] isSelected;
+	static int result;
+
+	public static void main(String[] args) throws Exception {
+		input = new LinkedList<Character>();
+		order = new LinkedList<Character>();
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		isSelected = new int[N];
+		
+		String str = br.readLine();
+		if (N == 1) { // 길이 1일 경우 바로 리턴
+			System.out.println(str);
+			return;
+		}
+
+		for (int i = 0; i < N; i++) { //수식 큐에 넣어줌
+			input.offer(str.charAt(i));
+		}
+
+		// 괄호 없는 순서대로 계산한 값으로 초기값 설정
+		result = input.peek() - '0';
+		for (int i = 1; i < N - 1; i += 2) {
+			result = calculate(result, str.charAt(i), str.charAt(i + 1) - '0');
+		}
+		bracket(0, 0); 
+		System.out.println(result);
+	}
+
+	//괄호 경우의 수 구하기
+	public static void bracket(int start, int cnt) {
+		if (start >= N - 1) { //수식의 마지막 숫자 앞에는 괄호를 씌울 수 없으므로 그 전 인덱스에서 종료처리
+			if (cnt != 0) { //공집합 제외
+				setOrder();
+				int num = order.poll() - '0';
+				while (!order.isEmpty()) {
+					num = calculate(num, order.poll(), order.poll() - '0');
+				}
+				result = Math.max(result, num);
+			}
+			return;
+		}
+		isSelected[start] = 1;
+		bracket(start + 4, cnt + 1); //현재 숫자에서 괄호가 열렸으면 다음에 괄호가 열릴 수 있는 인덱스는 현재 인덱스 +4
+		isSelected[start] = 0;
+		bracket(start + 2, cnt); //현재 숫자에서 괄호가 열리지 않았으면 다음에 괄호 열릴 수 있는 인덱스는 현재 인덱스+2
+
+	}
+
+	// 괄호에 따른 계산순서대로 큐에 넣어줌
+	public static void setOrder() {
+		Queue<Character> copied = new LinkedList<>();
+		copied.addAll(input);
+		int i=0;
+		while(!copied.isEmpty()) {
+			if (isSelected[i] == 1) { //괄호가 열렸다면
+				int result = copied.poll() - '0';
+				char op = copied.poll();
+				int a = copied.poll() - '0';
+				order.offer((char)(calculate(result,op,a)+'0')); //먼저 계산해서 큐에 넣어줌
+				i+=3;
+
+			} else { //괄호 없을경우
+				order.offer(copied.poll());
+				++i;
+			}
+		}
+	}
+
+	// 연산 부호에 따른 계산
+	public static int calculate(int result, char op, int a) {
+		if (op == '+') {
+			return result += a;
+		} else if (op == '-') {
+			return result -= a;
+		} else {
+			return result *= a;
+		}
+	}
+
+}

--- a/miir-jj/BOJ17135/BOJ17135.java
+++ b/miir-jj/BOJ17135/BOJ17135.java
@@ -1,0 +1,130 @@
+package BOJ0211;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/**
+ * 궁수 3명 3명의 위치를 열의 수 M에서 3개뽑는 조합으로 생성 적 죽이는 결과 MAX값 구하기 직진, 직진시 적없을때ㅣ 직진후 좌우
+ * 공격도 생각해야함
+ * 
+ *
+ */
+
+
+public class BOJ17135 {
+	static int N, M, D;
+	static int[] bow;
+	static ArrayList<int[]> archer;
+	static int[][] map;
+	static int[] dr = { 0, -1, 0 }; // 좌 상 우 순서로 하 제외
+	static int[] dc = { -1, 0, 1 };
+	static int answer;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		D = Integer.parseInt(st.nextToken());
+
+		bow = new int[M];
+		archer=new ArrayList<>(M);
+		map = new int[N][M];
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			for (int j = 0; j < M; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		comb(0, 0);
+		for(int[] i:archer) {
+			answer=Math.max(attack(i), answer);
+		}
+		System.out.println(answer);
+	}
+
+	// 궁수 위치 뽑기
+	public static void comb(int cnt, int start) {
+		if (cnt == 3) {
+			archer.add(bow.clone());
+			return;
+		}
+		for (int i = start; i < M; i++) {
+			bow[i] = 1;
+			comb(cnt + 1, i + 1);
+			bow[i] = 0;
+		}
+	}
+
+	// 적 공격
+	public static int attack(int[] b) {
+		int result=0;
+		Queue<int[]> target = new LinkedList<int[]>(); // 공격대상후보큐
+		boolean[][] attacked = new boolean[N][M]; // 공격대상
+		int[][] copied = copyMap();
+		for(int n=0;n<N;n++){
+				
+			for (int i = 0; i < M; i++) {
+				if (b[i] == 1) {
+					target.clear();
+					target.offer(new int[] { N - 1, i }); // 궁수로부터 한칸 위 칸부터 적이 있는지 검사
+
+					int[] tmp;
+					int nr, nc;
+					while (!target.isEmpty()) {
+						tmp = target.poll(); // 공격대상후보
+						if(getDistance(N, i, tmp[0], tmp[1])>D)
+							break;
+						if (copied[tmp[0]][tmp[1]] == 1) { // 적이면
+							attacked[tmp[0]][tmp[1]] = true;// 공격대상에 넣고
+							break; // 다음 궁수로
+						} else {
+							for (int j = 0; j < 3; j++) { // 좌 상 우 순으로
+								nr = tmp[0] + dr[j];
+								nc = tmp[1] + dc[j];
+								if (nr > -1 && nr < N && nc > -1 && nc < M ) { // 맵을 넘지 않으면
+									target.offer(new int[] { nr, nc });
+								}
+							}
+						}
+					}
+				}
+			}
+			for(int i=0;i<N;i++) {
+				for(int j=0;j<M;j++) {
+					if(attacked[i][j]) {
+						copied[i][j]=0;
+						result++;
+					}
+				}
+				Arrays.fill(attacked[i], false);
+			}
+			for(int i=N-1;i>0;i--) {
+				copied[i]=Arrays.copyOf(copied[i-1], M);
+			}
+			Arrays.fill(copied[0], 0);
+
+		}
+		return result;
+	}
+
+	// 맵 카피
+	public static int[][] copyMap() {
+		int[][] copy = new int[N][M];
+		for (int i = 0; i < N; i++) {
+			copy[i] = Arrays.copyOf(map[i], M);
+		}
+		return copy;
+	}
+
+	public static int getDistance(int r1, int c1, int r2, int c2) {
+		return Math.abs(r1-r2)+Math.abs(c1-c2);
+	}
+}

--- a/miir-jj/BOJ17135/BOJ17135.java
+++ b/miir-jj/BOJ17135/BOJ17135.java
@@ -9,13 +9,6 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.StringTokenizer;
 
-/**
- * 궁수 3명 3명의 위치를 열의 수 M에서 3개뽑는 조합으로 생성 적 죽이는 결과 MAX값 구하기 직진, 직진시 적없을때ㅣ 직진후 좌우
- * 공격도 생각해야함
- * 
- *
- */
-
 
 public class BOJ17135 {
 	static int N, M, D;

--- a/miir-jj/BOJ2504/BOJ2504.java
+++ b/miir-jj/BOJ2504/BOJ2504.java
@@ -1,0 +1,66 @@
+package BOJ0211;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Stack;
+
+public class BOJ2504 {
+	static Stack<Character> open = new Stack<Character>();
+	static Stack<Integer> num = new Stack<Integer>();
+	static String input;
+	static int result;
+
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		Stack<Character> open=new Stack<Character>();
+		input = br.readLine();
+		
+		char ch;
+		int tmp=1, result=0;
+		boolean check=true;
+
+		for (int i = 0; i < input.length(); i++) {
+			ch=input.charAt(i);
+			switch (ch) {
+			case '(':
+				open.push(ch);
+				tmp*=2;
+				break;
+			case '[':
+				open.push(ch);
+				tmp*=3;
+				break;
+			case ')':
+				if(open.isEmpty()||open.peek()!='(') {
+					check=false;
+					break;
+				}
+				if(input.charAt(i-1)=='(') { //연속된 괄호일 경우에만 result 더해줌(포함된 모든 괄호가 닫힘을 의미)
+					result+=tmp;
+				}
+				open.pop();
+				tmp/=2;
+				break;
+			case ']':
+				if(open.isEmpty()||open.peek()!='[') { //런타임 에러 peek을 먼저 할경우
+					check=false;
+					break;
+				}
+				if(input.charAt(i-1)=='[') {
+					result+=tmp;
+				}
+				open.pop();
+				tmp/=3;
+				break;
+			}
+		}
+		if(check&&open.empty())//괄호가 열리고 닫히지 않은 경우
+			System.out.println(result);
+		else
+			System.out.println(0);
+	}
+
+}

--- a/miir-jj/BOJ2504/BOJ2504.java
+++ b/miir-jj/BOJ2504/BOJ2504.java
@@ -38,7 +38,7 @@ public class BOJ2504 {
 					check=false;
 					break;
 				}
-				if(input.charAt(i-1)=='(') { //연속된 괄호일 경우에만 result 더해줌(포함된 모든 괄호가 닫힘을 의미)
+				if(input.charAt(i-1)=='(') { //연속된 괄호일 경우에만 result 더해줌(중첩된 모든 괄호가 닫힘을 의미)
 					result+=tmp;
 				}
 				open.pop();


### PR DESCRIPTION
# BOJ 2504번 [괄호의 값](https://www.acmicpc.net/problem/2504)

## 🌈 풀이 후기
괄호가 중첩되어 있는 부분을 구현했을 때 고려하지 않았던 부분들이 많아 코드를 여러번 수정해야했습니다.

## 👩 🏫 문제 풀이
1. String으로 받아와 index를 이용해 char형으로 값 비교
2. tmp : 중첩된 괄호 연산을 처리하기 위한 변수 / result : 최종 결과 값
3. '(' 와 '['일 경우 tmp에 각각 2와 3을 곱해주고, open 스택에 문자를 push해줌
4. ')' 와 ']'일 경우 
4-1.  open스택이 비어있거나 짝이 되는 괄호가 맞는 짝이 아닐경우 check를 false로 변경해줌
4-2. 그외의 경우이면서 바로 전 인덱스 값이 짝이 맞는 괄호일 경우 result에 tmp를 더해줌
4-3. open에서 pop해주고 tmp를 괄호에 맞는 값으로 나눠줌(중첩된 괄호에서 빠져나옴을 의미)
5. check가 true이면서 open스택이 비어있으면 올바른 result 출력, 그외에는 0출력


#
# BOJ 17135번 [캐슬 디펜스](https://www.acmicpc.net/problem/17135)

## 🌈 풀이 후기
계속 메모리초과가 나서 고쳐보는 중입니다🤯
## 👩 🏫 문제 풀이




#
# BOJ 1182번 [부분수열의 합](https://www.acmicpc.net/problem/1182)

## 🌈 풀이 후기
처음에 주어진 정수를 연속되게 뽑아야 하는 것으로 문제를 잘못 이해했었습니다.
이후에 제대로 이해하고 나서는 수업에서 배운 비트마스크를 활용하면 쉽게 풀 수 있었습니다!
캐슬 디펜스가 너무 어려웠는데 단비같은 문제였습니다ㅠㅠ
## 👩 🏫 문제 풀이
1. num배열에 주어진 숫자들을 저장
2. N개의 원소를 확인할거니까 i가 2의 n-1승 될때까지 반복
2-1. N번만큼 반복돌며 j만큼 시프트 시킨 2진수와 i를 and연산
2-2. and연산 결과 0이 아니면 해당 자리의 배열값 sum에 더해줌
2-3. sum이 S가 됬을때 result+1해줌
3. result 출력