### PR TITLE
박현우 : BOJ 2629 양팔저울

### DIFF
--- a/Hyeonwoo-Park/BOJ2629/README.md
+++ b/Hyeonwoo-Park/BOJ2629/README.md
@@ -1,0 +1,9 @@
+# BOJ 2629번 [양팔저울](http://noj.am/2629)
+
+## 🌈 풀이 후기
+- Set을 foreach구문 안에서 변경하게 될 경우 `ConcurrentModificationException`예외가 발생합니다.
+- `CopyOnWriteArraySet`를 사용해서 해결했습니다.
+## 👩‍🏫 문제 풀이
+- 입력을 받으면서
+    - |set에 들어있는 값에 입력을 뺀값|, set에 들어있는 값에 입력을 더한값을 추가합니다.
+- 이후 구슬을 입력받으면서 셋에 있는 값인지 확인합니다.

--- a/Hyeonwoo-Park/BOJ2629/Scale.java
+++ b/Hyeonwoo-Park/BOJ2629/Scale.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+public class Scale {
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(reader.readLine());
+		StringTokenizer token = new StringTokenizer(reader.readLine());
+		Set<Integer> s = new CopyOnWriteArraySet<>();
+		s.add(0);
+
+		for (int i = 0; i < N; ++i) {
+			int inp = Integer.parseInt(token.nextToken());
+
+			for (Integer num : s) {
+				if (num - inp > 0)
+					s.add(num - inp);
+				else
+					s.add(inp - num);
+
+				s.add(num + inp);
+			}
+		}
+
+		int M = Integer.parseInt(reader.readLine());
+		token = new StringTokenizer(reader.readLine());
+
+		for (int i = 0; i < M; ++i) {
+			int inp = Integer.parseInt(token.nextToken());
+			
+			if (s.contains(inp))
+				System.out.print("Y ");
+			else
+				System.out.print("N ");
+		}
+	}
+}


### PR DESCRIPTION
# BOJ 2629번 [양팔저울](http://noj.am/2629)

## 🌈 풀이 후기
- Set을 foreach구문 안에서 변경하게 될 경우 `ConcurrentModificationException`예외가 발생합니다.
- `CopyOnWriteArraySet`를 사용해서 해결했습니다.
## 👩‍🏫 문제 풀이
- 입력을 받으면서
    - |set에 들어있는 값에 입력을 뺀값|, set에 들어있는 값에 입력을 더한값을 추가합니다.
- 이후 구슬을 입력받으면서 셋에 있는 값인지 확인합니다.